### PR TITLE
minor grammar fix to chap 3

### DIFF
--- a/en/03-git-branching/01-chapter3.markdown
+++ b/en/03-git-branching/01-chapter3.markdown
@@ -403,7 +403,7 @@ To demonstrate having multiple remote servers and what remote branches for those
 Insert 18333fig0325.png 
 Figure 3-25. Adding another server as a remote.
 
-Now, you can run `git fetch teamone` to fetch everything server has that you don’t have yet. Because that server is a subset of the data your `origin` server has right now, Git fetches no data but sets a remote branch called `teamone/master` to point to the commit that `teamone` has as its `master` branch (see Figure 3-26).
+Now, you can run `git fetch teamone` to fetch everything the remote `teamone` server has that you don’t have yet. Because that server is a subset of the data your `origin` server has right now, Git fetches no data but sets a remote branch called `teamone/master` to point to the commit that `teamone` has as its `master` branch (see Figure 3-26).
 
 Insert 18333fig0326.png 
 Figure 3-26. You get a reference to teamone’s master branch position locally.


### PR DESCRIPTION
Fixed up a sentence in 3.5 explaining the `git fetch teamone` remote branching example.
