### PR TITLE
Rakefile UTF-8 encoding conflicts

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -151,3 +151,10 @@ namespace :epub do
 	CLEAN << TMP_DIR
 	CLOBBER << TARGET_FILEPATH
 end
+
+namespace :pdf do
+        desc "generate a pdf"
+        task :generate  do
+                system("ruby makepdfs")
+        end
+end


### PR DESCRIPTION
Interpret the mk.read() as UTF-8. This way there is not a conflict in encoding types, inside the maruku library. Like the error below:

<code>
incompatible encoding regexp match (UTF-8 regexp with ISO-8859-1 string)
/usr/lib64/ruby/1.9.1/rexml/text.rb:132:in `=~'
/usr/lib64/ruby/1.9.1/rexml/text.rb:132:in`!~'
/usr/lib64/ruby/1.9.1/rexml/text.rb:132:in `check'
/usr/lib64/ruby/1.9.1/rexml/text.rb:125:in`parent='
/usr/lib64/ruby/1.9.1/rexml/parent.rb:19:in `add'
/usr/lib64/ruby/gems/1.9.1/gems/maruku-0.6.0/lib/maruku/output/to_html.rb:651:in`to_html_code_using_pre'
/usr/lib64/ruby/gems/1.9.1/gems/maruku-0.6.0/lib/maruku/output/to_html.rb:597:in `to_html_code'
/usr/lib64/ruby/gems/1.9.1/gems/maruku-0.6.0/lib/maruku/output/to_html.rb:970:in`block in array_to_html'
/usr/lib64/ruby/gems/1.9.1/gems/maruku-0.6.0/lib/maruku/output/to_html.rb:961:in `each'
/usr/lib64/ruby/gems/1.9.1/gems/maruku-0.6.0/lib/maruku/output/to_html.rb:961:in`array_to_html'
/usr/lib64/ruby/gems/1.9.1/gems/maruku-0.6.0/lib/maruku/output/to_html.rb:956:in `children_to_html'
/usr/lib64/ruby/gems/1.9.1/gems/maruku-0.6.0/lib/maruku/output/to_html.rb:50:in`to_html'
/home/vbatts/src/progit/Rakefile:64:in `block (4 levels) in <top (required)>'
/home/vbatts/src/progit/Rakefile:63:in`open'
/home/vbatts/src/progit/Rakefile:63:in `block (3 levels) in <top (required)>'
/home/vbatts/src/progit/Rakefile:62:in`open'
/home/vbatts/src/progit/Rakefile:62:in `block (2 levels) in <top (required)>'
</code>
