### PR TITLE
fix makepdf for Windows

### DIFF
--- a/latex/README
+++ b/latex/README
@@ -10,3 +10,18 @@ pandoc and XeTeX as dependencies.
 * `template.tex`: this is the main LaTeX file which determines the style of the
   PDF version of the book. Its contents is run through the ERB templating
   language to include language-specific customisations from config.yml.
+
+
+For Windows
+===========
+
+Windows build is tested with Pandoc 1.8 and MixTeX 2.9. Install MixTeX with all
+font options. Only `en` has been tested so far. To make it work, it needs some
+tweaks.
+
+* `pandoc` and `xelatex` binaries must be on the PATH
+* Change the default fonts in `config.yml` to something that exists in Windows.
+  Example for working fonts:
+    font: Latin Modern Roman
+    mono: Courier
+    bold: "{*}"

--- a/latex/makepdf
+++ b/latex/makepdf
@@ -1,12 +1,10 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
 require 'fileutils'
-require 'open3'
 require 'erb'
 require 'yaml'
 
-include FileUtils, Open3
-alias :pipe :popen3
+include FileUtils
 
 $here = File.expand_path(File.dirname(__FILE__))
 $root = File.join($here, '..')
@@ -37,8 +35,12 @@ USAGE
 end
 
 def command_exists?(command)
-	ENV['PATH'].split(/:/).map do |path|
-		File.executable?("#{path}/#{command}")
+	if File.executable?(command) then
+		return command
+	end
+	ENV['PATH'].split(File::PATH_SEPARATOR).map do |path|
+		cmd = "#{path}/#{command}"
+		File.executable?(cmd) || File.executable?("#{cmd}.exe") || File.executable?("#{cmd}.cmd")
 	end.inject{|a, b| a || b}
 end
 
@@ -133,10 +135,10 @@ figures do
 		end.join("\n\n")
 
 		print "\tParsing markdown... "
-		latex = pipe('pandoc -p --no-wrap -f markdown -t latex') do |stdin, stdout|
-			stdin.write(pre_pandoc(markdown, config))
-			stdin.close
-			post_pandoc(stdout.read, config)
+		latex = IO.popen('pandoc -p --no-wrap -f markdown -t latex', 'w+') do |pipe|
+			pipe.write(pre_pandoc(markdown, config))
+			pipe.close_write
+			post_pandoc(pipe.read, config)
 		end
 		puts "done"
 
@@ -154,15 +156,15 @@ figures do
 		cd($root)
 		3.times do |i|
 			print "\t\tPass #{i + 1}... "
-			pipe("xelatex -output-directory='#{dir}' '#{dir}/main.tex' 2>&1") do |_, stdout|
+			IO.popen("xelatex -output-directory=\"#{dir}\" \"#{dir}/main.tex\" 2>&1") do |pipe|
 				unless $DEBUG
 					if ~ /^!\s/
 						puts "failed with:\n\t\t\t#{$_.strip}"
 						puts "\tConsider running this again with --debug."
 						abort = true
-					end while stdout.gets and not abort
+					end while pipe.gets and not abort
 				else
-					STDERR.print while stdout.gets rescue abort = true
+					STDERR.print while pipe.gets rescue abort = true
 				end
 			end
 			break if abort

--- a/latex/template.tex
+++ b/latex/template.tex
@@ -18,7 +18,7 @@
 
 \definecolor{shadecolor}{gray}{0.90}
 
-\setromanfont[Mapping=tex-text,Bold=<%= config['bold'] %>]{<%= config['font'] %>}
+\setromanfont[Mapping=tex-text,BoldFont=<%= config['bold'] %>]{<%= config['font'] %>}
 \setmonofont{<%= config['mono'] %>}
 
 \XeTeXlinebreaklocale{<%= lang %>}


### PR DESCRIPTION
This fixes the 'makepdf' build to work on Windows with at least MixTeX 2.9
and Pandoc 1.8.
- Fix command_exists to use the correct File::PATH_SEPARATOR and allow
  *.exe and *.cmd
- Use IO.popen instead of popen3 to be portable
- Update README for Windows build
- Fix template.tex to use BoldFont instead of Bold in \setfromanfont
  (this affected me on OSX and Linux too)

Signed-off-by: Daniel Ritz daniel.ritz@gmx.ch
