### PR TITLE
Mistake

### DIFF
--- a/pl/02-git-basics/02-chapter2.markdown
+++ b/pl/02-git-basics/02-chapter2.markdown
@@ -59,7 +59,7 @@ Podstawowe narzędzie używane do sprawdzenia stanu plików to polecenie `git st
 
 Oznacza to, że posiadasz czysty katalog roboczy — innymi słowy nie zawiera on śledzonych i zmodyfikowanych plików. Git nie widzi także żadnych plików nieśledzonych, w przeciwnym wypadku wyświetliłby ich listę. W końcu polecenie pokazuje również gałąź, na której aktualnie pracujesz. Póki co, jest to zawsze master, wartość domyślna; nie martw się tym jednak teraz. Następny rozdział w szczegółach omawia gałęzie oraz odniesienia.
 
-Powiedzmy, że dodajesz do repozytorium nowy plik, prosty plik README. Jeżeli nie istniał on wcześniej, po uruchomieniu `git status` zobaczysz go jako plik nieśledzony, jak poniżej:
+Powiedzmy, że dodajesz do repozytorium nowy, prosty plik README. Jeżeli nie istniał on wcześniej, po uruchomieniu `git status` zobaczysz go jako plik nieśledzony, jak poniżej:
 
 	$ vim README
 	$ git status


### PR DESCRIPTION
There was a mistake in polish translation. Word "plik" was two times written, but there was no necessary to do it and it was looking ridiculously. Thanks.
