### PR TITLE
[ko] revert font setting in latex/config.yml

### DIFF
--- a/latex/config.yml
+++ b/latex/config.yml
@@ -1,7 +1,7 @@
 default:
-  font: Liberation Serif
+  font: Helvetica
   bold: "{* Bold}"
-  mono: Liberation Mono
+  mono: Andale Mono
   prechap: "Chapter "
   postchap: ""
   presect: "Section "


### PR DESCRIPTION
Revert before ee73af4544669856a32c9b26dd9e598f74c52b01.
It was a mistake.
