### PR TITLE
[ja] fix makeebooks to insert figures correctly when lang == ja

### DIFF
--- a/makeebooks
+++ b/makeebooks
@@ -29,6 +29,8 @@ ARGV.each do |lang|
 
   if lang == 'ko'
     figure_title = '그림'
+  elsif lang == 'ja'
+    figure_title = '図'
   else
     figure_title = 'Figure'
   end
@@ -38,7 +40,7 @@ ARGV.each do |lang|
   Dir[File.join(dir, '**', '*.markdown')].sort.each do |input|
     puts "processing #{input}"
     content = File.read(input)
-    content.gsub!(/Insert\s+(.*)(\.png)\s*\n?\s*#{figure_title}\s+(.*)/, '![\3](figures/\1-tn\2 "\3")')
+    content.gsub!(/Insert\s+(.*)(\.png)\s*\n?\s*#{figure_title}\s*(.*)/, '![\3](figures/\1-tn\2 "\3")')
     book_content << RDiscount.new(content).to_html
   end
   book_content << "</body></html>"


### PR DESCRIPTION
When Japanese, `makeebooks' command failed to insert figures correctly. It might be partly due to the translations. But, to be done by this tiny tweak works fine.
