### PR TITLE
Customizing git: Fix a wrong statement about line endings

### DIFF
--- a/en/07-customizing-git/01-chapter7.markdown
+++ b/en/07-customizing-git/01-chapter7.markdown
@@ -214,7 +214,7 @@ Formatting and whitespace issues are some of the more frustrating and subtle pro
 
 #### core.autocrlf ####
 
-If you’re programming on Windows or using another system but working with people who are programming on Windows, you’ll probably run into line-ending issues at some point. This is because Windows uses both a carriage-return character and a linefeed character for newlines in its files, whereas Mac and Linux systems use only the linefeed character. This is a subtle but incredibly annoying fact of cross-platform work. 
+If you’re programming on Windows or using another system but working with people who are programming on Windows, you’ll probably run into line-ending issues at some point. This is because Windows uses both a carriage-return character and a linefeed character for newlines in its files, whereas Mac and Linux uses only carriage return(\r) and linefeed(\n) character respectively. This is a subtle but incredibly annoying fact of cross-platform work. 
 
 Git can handle this by auto-converting CRLF line endings into LF when you commit, and vice versa when it checks out code onto your filesystem. You can turn on this functionality with the `core.autocrlf` setting. If you’re on a Windows machine, set it to `true` — this converts LF endings into CRLF when you check out code:
 


### PR DESCRIPTION
Fix a wrong statement that Mac and Linux systems uses same line endings

Signed-off-by: Vikram Narayanan vikram186@gmail.com
