### PR TITLE
Fix Ruby syntax error in git ACL policy hook

### DIFF
--- a/ar/07-customizing-git/01-chapter7.markdown
+++ b/ar/07-customizing-git/01-chapter7.markdown
@@ -672,8 +672,8 @@ If you use the ACL structure returned from the `get_acl_access_data` method and 
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/ca/07-customizing-git/01-chapter7.markdown
+++ b/ca/07-customizing-git/01-chapter7.markdown
@@ -672,8 +672,8 @@ If you use the ACL structure returned from the `get_acl_access_data` method and 
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/cs/07-customizing-git/01-chapter7.markdown
+++ b/cs/07-customizing-git/01-chapter7.markdown
@@ -672,8 +672,8 @@ If you use the ACL structure returned from the `get_acl_access_data` method and 
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/de/07-customizing-git/01-chapter7.markdown
+++ b/de/07-customizing-git/01-chapter7.markdown
@@ -938,8 +938,8 @@ If you use the ACL structure returned from the `get_acl_access_data` method and 
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/en/07-customizing-git/01-chapter7.markdown
+++ b/en/07-customizing-git/01-chapter7.markdown
@@ -734,8 +734,8 @@ If you use the ACL structure returned from the `get_acl_access_data` method and 
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/es-ni/07-customizing-git/01-chapter7.markdown
+++ b/es-ni/07-customizing-git/01-chapter7.markdown
@@ -672,8 +672,8 @@ If you use the ACL structure returned from the `get_acl_access_data` method and 
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/es/07-customizing-git/01-chapter7.markdown
+++ b/es/07-customizing-git/01-chapter7.markdown
@@ -670,8 +670,8 @@ Utilizando la estructura ACL devuelta por el método 'get_acl_access_data' y com
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/es/GitPro-omegat-Benzirpi.tmx
+++ b/es/GitPro-omegat-Benzirpi.tmx
@@ -17461,8 +17461,8 @@ Figura 7-3.</seg>
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end
@@ -17483,8 +17483,8 @@ Figura 7-3.</seg>
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/ja/07-customizing-git/01-chapter7.markdown
+++ b/ja/07-customizing-git/01-chapter7.markdown
@@ -672,8 +672,8 @@ SHA-1 値がわかっているときにコミットからコミットメッセ�
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/mk/07-customizing-git/01-chapter7.markdown
+++ b/mk/07-customizing-git/01-chapter7.markdown
@@ -672,8 +672,8 @@ If you use the ACL structure returned from the `get_acl_access_data` method and 
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/pt-br/07-customizing-git/01-chapter7.markdown
+++ b/pt-br/07-customizing-git/01-chapter7.markdown
@@ -672,8 +672,8 @@ If you use the ACL structure returned from the `get_acl_access_data` method and 
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/ru/07-customizing-git/01-chapter7.markdown
+++ b/ru/07-customizing-git/01-chapter7.markdown
@@ -673,8 +673,8 @@ If you use the ACL structure returned from the `get_acl_access_data` method and 
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/th/07-customizing-git/01-chapter7.markdown
+++ b/th/07-customizing-git/01-chapter7.markdown
@@ -672,8 +672,8 @@ If you use the ACL structure returned from the `get_acl_access_data` method and 
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/tr/07-customizing-git/01-chapter7.markdown
+++ b/tr/07-customizing-git/01-chapter7.markdown
@@ -672,8 +672,8 @@ If you use the ACL structure returned from the `get_acl_access_data` method and 
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end

--- a/zh-tw/07-customizing-git/01-chapter7.markdown
+++ b/zh-tw/07-customizing-git/01-chapter7.markdown
@@ -677,8 +677,8 @@ A simple way to get the commit message from a commit when you have the SHA-1 val
 	      next if path.size == 0
 	      has_file_access = false
 	      access[$user].each do |access_path|
-	        if !access_path  # user has access to everything
-	          || (path.index(access_path) == 0) # access to this path
+	        if !access_path || # user has access to everything
+	          (path.index(access_path) == 0) # access to this path
 	          has_file_access = true 
 	        end
 	      end


### PR DESCRIPTION
There's a tiny Ruby syntax error in a hook that shows enforced ACL policy.
