### PR TITLE
Update Gitolite documentation link.

### DIFF
--- a/en/04-git-server/01-chapter4.markdown
+++ b/en/04-git-server/01-chapter4.markdown
@@ -507,7 +507,7 @@ If you have any issues, it may be useful to add `loglevel=DEBUG` under the `[git
 
 Note: the latest copy of this section of the ProGit book is always available within the [gitolite documentation][gldpg].  The author would also like to humbly state that, while this section is accurate, and *can* (and often *has*) been used to install gitolite without reading any other documentation, it is of necessity not complete, and cannot completely replace the enormous amount of documentation that gitolite comes with.
 
-[gldpg]: http://github.com/sitaramc/gitolite/blob/pu/doc/progit-article.mkd
+[gldpg]: http://sitaramc.github.com/gitolite/progit.html
 
 Git has started to become very popular in corporate environments, which tend to have some additional requirements in terms of access control.  Gitolite was originally created to help with those requirements, but it turns out that it's equally useful in the open source world: the Fedora Project controls access to their package management repositories (over 10,000 of them!) using gitolite, and this is probably the largest gitolite installation anywhere too.
 


### PR DESCRIPTION
Current Gitolite documentation link is obsolete. I updated the link to use this url: http://sitaramc.github.com/gitolite/progit.html

See [gitscm-next Issue #131](https://github.com/github/gitscm-next/issues/131)
