### PR TITLE
[es] fix makeebooks to insert figures correctly when language is spanish, chinese or chinese (taiwan)

### DIFF
--- a/makeebooks
+++ b/makeebooks
@@ -33,6 +33,10 @@ ARGV.each do |lang|
     figure_title = 'Рисунок'
   elsif lang == 'es'
     figure_title = 'Figura'
+  elsif lang == 'zh'
+    figure_title = '图'
+  elsif lang == 'zh-tw'
+    figure_title = '圖'
   else
     figure_title = 'Figure'
   end


### PR DESCRIPTION
When you run makeebooks script with parameter for spanish, chinese or chinese (taiwan) translation
(es, zh, and zh-tw respectively) the result didn't render the figures. I've solved it adding some lines to makeebooks.
