### PR TITLE
Fixed pdf generation with deep subsections

### DIFF
--- a/latex/makepdf
+++ b/latex/makepdf
@@ -61,7 +61,7 @@ end
 def pre_pandoc(string, config)
 	replace(string) do
 		# Pandoc discards #### subsubsections #### - this hack recovers them
-		s /\#\#\#\# (.*?) \#\#\#\#/, 'SUBSUBSECTION: \1'
+		s /\#\#\#\#\#\#\#\#\#\#\#\# (.*?) \#\#\#\#\#\#\#\#\#\#\#\#/, 'SUBSUBSECTION: \1'
 
 		# Turns URLs into clickable links
 		s /\`(http:\/\/[A-Za-z0-9\/\%\&\=\-\_\\\.]+)\`/, '<\1>'


### PR DESCRIPTION
Pdf generation failed for chapters with more than 4 nested subsections,
so first “#” character on fifth subsection was treated as new chapter.

This isn't a real fix, just reserved up to 12 nested subsections.
