### PR TITLE
[ptbr] Add missing Brazilian Portuguese image conversion during ebook creation

### DIFF
--- a/makeebooks
+++ b/makeebooks
@@ -38,6 +38,8 @@ ARGV.each do |lang|
     figure_title = '图'
   elsif lang == 'zh-tw'
     figure_title = '圖'
+  elsif lang == 'pt-br'
+    figure_title = 'Figura'
   else
     figure_title = 'Figure'
   end


### PR DESCRIPTION
Add missing Brazilian Portuguese image conversion during ebook creation.

Thanks to @apinheiro for pointing this issue and giving the solution on https://github.com/progit/progit/issues/292.
