### PR TITLE
Fix: export-ignore: tests/ => /tests

### DIFF
--- a/en/07-customizing-git/01-chapter7.markdown
+++ b/en/07-customizing-git/01-chapter7.markdown
@@ -508,7 +508,7 @@ You can tell Git not to export certain files or directories when generating an a
 
 For example, say you have some test files in a `test/` subdirectory, and it doesn’t make sense to include them in the tarball export of your project. You can add the following line to your Git attributes file:
 
-	test/ export-ignore
+	/test export-ignore
 
 Now, when you run git archive to create a tarball of your project, that directory won’t be included in the archive.
 


### PR DESCRIPTION
It's much better to use:

```
/tests export-ignore
```

than

```
tests/ export-ignore
```

The rule:

```
tests/ export-ignore
```

doesn't work on Windows and it probably covers all subdirectories. If we want to cover all subdirectories why not use:

```
tests export-ignore
```

Anyway, the rule:

```
/tests export-ignore
```

works both on unix and windows and it covers only one directory (the one from root dir).
