### PR TITLE
fix spurious errors while compiling to pdf

### DIFF
--- a/latex/makepdf
+++ b/latex/makepdf
@@ -181,7 +181,7 @@ figures do
 			print "\t\tPass #{i + 1}... "
 			IO.popen("xelatex -output-directory=\"#{dir}\" \"#{dir}/main.tex\" 2>&1") do |pipe|
 				unless $DEBUG
-					if ~ /^!\s/
+					if $_[0..1]=='! '
 						puts "failed with:\n\t\t\t#{$_.strip}"
 						puts "\tConsider running this again with --debug."
 						abort = true


### PR DESCRIPTION
The makepdf script monitors latex by looking for lines beginning
by '! ' in the logs. Unfortunately, it uses a regexp while latex
seems to spit lines which are not perfect utf-8. The regexp may raise
an exception.

It is safer to just check the first two characters of each line.
This may fix github/progit#12
