### PR TITLE
Set the typewrite text font size in latex template

### DIFF
--- a/latex/makepdf
+++ b/latex/makepdf
@@ -101,13 +101,7 @@ def post_pandoc(string, config)
 		s /\sx\s10\\\^\{\}(\d+)/, '\e{\1}'
 
 		# Convert inline-verbatims into \texttt (which is able to wrap)
-		s /\\verb(\W)(.*?)\1/ do
-			"{\\texttt{#{verbatim_sanitize($2)}}}"
-		end
-
-		# Ensure monospaced stuff is in a smaller font
-		s /(\\verb(\W).*?\2)/, '{\footnotesize\1}'
-		s /(\\begin\{verbatim\}.*?\\end\{verbatim\})/m, '{\footnotesize\1}'
+		s /\\verb(\W)(.*?)\1/ ,'\\texttt{\2}'
 
 		# Make Tables 2-1..2-3 actual tables
 		s /\\begin\{verbatim\}\n(([^\t\n]+\t.*?\n)+)(([^\t\n]*)\n)?\\end\{verbatim\}/ do

--- a/latex/template.tex
+++ b/latex/template.tex
@@ -17,7 +17,7 @@
 \definecolor{shadecolor}{gray}{0.90}
 
 \setromanfont[Mapping=tex-text,BoldFont=<%= config['bold'] %>]{<%= config['font'] %>}
-\setmonofont{<%= config['mono'] %>}
+\setmonofont[Scale=.85]{<%= config['mono'] %>}
 
 \XeTeXlinebreaklocale{<%= lang %>}
 <%= config['langrule'] %>


### PR DESCRIPTION
Instead of applying the font size change at each occurence of texttt,
set the monofont size at the declaration.
