### PR TITLE
Better wording for 'git rm' use-case

### DIFF
--- a/en/02-git-basics/01-chapter2.markdown
+++ b/en/02-git-basics/01-chapter2.markdown
@@ -366,7 +366,7 @@ Then, if you run `git rm`, it stages the file’s removal:
 
 The next time you commit, the file will be gone and no longer tracked. If you modified the file and added it to the index already, you must force the removal with the `-f` option. This is a safety feature to prevent accidental removal of data that hasn’t yet been recorded in a snapshot and that can’t be recovered from Git.
 
-Another useful thing you may want to do is to keep the file in your working tree but remove it from your staging area. In other words, you may want to keep the file on your hard drive but not have Git track it anymore. This is particularly useful if you forgot to add something to your `.gitignore` file and accidentally added it, like a large log file or a bunch of `.a` compiled files. To do this, use the `--cached` option:
+Another useful thing you may want to do is to keep the file in your working tree but remove it from your staging area. In other words, you may want to keep the file on your hard drive but not have Git track it anymore. This is particularly useful if you forgot to add something to your `.gitignore` file and accidentally staged it, like a large log file or a bunch of `.a` compiled files. To do this, use the `--cached` option:
 
 	$ git rm --cached readme.txt
 


### PR DESCRIPTION
The example uses the word "add" twice in the same sentence with two different meanings, for staging a file and for adding it to `.gitignore`. I changed "added" to "staged" just to make the meaning more clear.
