### PR TITLE
Remove cruft sentence from Chapter 6.

### DIFF
--- a/en/06-git-tools/01-chapter6.markdown
+++ b/en/06-git-tools/01-chapter6.markdown
@@ -669,7 +669,7 @@ Splitting a commit undoes a commit and then partially stages and commits as many
 	edit 310154e updated README formatting and added blame
 	pick a5f4a0d added cat-file
 
-Then, when the script drops you to the command line, you reset that commit, take the changes that have been reset, and create multiple commits out of them. When you save and exit the editor, Git rewinds to the parent of the first commit in your list, applies the first commit (`f7f3f6d`), applies the second (`310154e`), and drops you to the console. There, you can do a mixed reset of that commit with `git reset HEAD^`, which effectively undoes that commit and leaves the modified files unstaged. Now you can stage and commit files until you have several commits, and run `git rebase --continue` when you’re done:
+When you save and exit the editor, Git rewinds to the parent of the first commit in your list, applies the first commit (`f7f3f6d`), applies the second (`310154e`), and drops you to the console. There, you can do a mixed reset of that commit with `git reset HEAD^`, which effectively undoes that commit and leaves the modified files unstaged. Now you can take the changes that have been reset, and create multiple commits out of them. Simply stage and commit files until you have several commits, and run `git rebase --continue` when you’re done:
 
 	$ git reset HEAD^
 	$ git add README


### PR DESCRIPTION
This sentence in 'Splitting a Commit' described the same events as
the sentences following it, only in less detail. It appears that at
some point the content was fleshed out, but the original sentence
got left in by mistake.
