### PR TITLE
Add backticks around `git fetch pb` in section 2.5.

### DIFF
--- a/en/02-git-basics/01-chapter2.markdown
+++ b/en/02-git-basics/01-chapter2.markdown
@@ -754,7 +754,7 @@ I’ve mentioned and given some demonstrations of adding remote repositories in 
 	origin	git://github.com/schacon/ticgit.git
 	pb	git://github.com/paulboone/ticgit.git
 
-Now you can use the string `pb` on the command line in lieu of the whole URL. For example, if you want to fetch all the information that Paul has but that you don’t yet have in your repository, you can run git fetch pb:
+Now you can use the string `pb` on the command line in lieu of the whole URL. For example, if you want to fetch all the information that Paul has but that you don’t yet have in your repository, you can run `git fetch pb`:
 
 	$ git fetch pb
 	remote: Counting objects: 58, done.


### PR DESCRIPTION
Following the example of the preceding `git remote add`.
