### PR TITLE
08-git-and-other-scms: Fix german translation for users.txt redirection

### DIFF
--- a/de/08-git-and-other-scms/01-chapter8.markdown
+++ b/de/08-git-and-other-scms/01-chapter8.markdown
@@ -492,7 +492,7 @@ Um eine Liste der Namen der Autoren bekommen, die SVN benutzen, kannst Du folgen
 
 <!--That gives you the log output in XML format — you can look for the authors, create a unique list, and then strip out the XML. (Obviously this only works on a machine with `grep`, `sort`, and `perl` installed.) Then, redirect that output into your users.txt file so you can add the equivalent Git user data next to each entry.-->
 
-Dies erzeugt Dir die Log-Ausgabe im XML-Format — Du suchst damit nach den Autoren, erzeugst eine Liste ohne doppelte Einträge und wirfst anschließend das überflüssige XML weg. Anschließend wird die Ausgabe in die Datei `users.txt` umgeleitet, so dass Du jedem Eintrag den entsprechenden Git-Benutzer zuordnen kannst.
+Dies erzeugt Dir die Log-Ausgabe im XML-Format — Du suchst damit nach den Autoren, erzeugst eine Liste ohne doppelte Einträge und wirfst anschließend das überflüssige XML weg. Leite anschließend die Ausgabe in die Datei `users.txt` um, so dass Du jedem Eintrag den entsprechenden Git-Benutzer zuordnen kannst.
 
 <!--You can provide this file to `git svn` to help it map the author data more accurately. You can also tell `git svn` not to include the metadata that Subversion normally imports, by passing `-\-no-metadata` to the `clone` or `init` command. This makes your `import` command look like this:-->
 


### PR DESCRIPTION
The German translation regarding the redirection to the users.txt
file does not match exactly the English original version.
