### PR TITLE
Fix quoting of cmd in .gitconfig example

### DIFF
--- a/en/07-customizing-git/01-chapter7.markdown
+++ b/en/07-customizing-git/01-chapter7.markdown
@@ -178,7 +178,7 @@ or you can edit your `~/.gitconfig` file to add these lines:
 	[merge]
 	  tool = extMerge
 	[mergetool "extMerge"]
-	  cmd = extMerge "$BASE" "$LOCAL" "$REMOTE" "$MERGED"
+	  cmd = extMerge \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\"
 	  trustExitCode = false
 	[diff]
 	  external = extDiff


### PR DESCRIPTION
The .gitconfig example in Chapter 7 is slightly wrong: the quotes need to be escaped.  Otherwise, git's ini parser will strip them out.
