### PR TITLE
add '\usepackage{longtable}' to fix 'problem Environment longtable undefined'

### DIFF
--- a/latex/template.tex
+++ b/latex/template.tex
@@ -14,6 +14,7 @@
 \usepackage{indentfirst}
 \usepackage{framed,color}
 \usepackage{caption}
+\usepackage{longtable}
 \captionsetup{font=bf,position=below}
 
 \usepackage{ctable}


### PR DESCRIPTION
On my archlinux

$ ./makepdfs zh

reports such problem

$     ! LaTeX Error: Environment longtable undefined.

In my case, add  \usepackage{longtable}  into latex/template.tex just fix the problem.
