### PR TITLE
Updated readme with MacOS dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ On MacOS you can do like this::
 	
 1. INSTALL ruby and rubygems
 2. `$ gem install rdiscount`
-3. DOWNLOAD Calibre for MacOS and install command line tools
+3. DOWNLOAD Calibre for MacOS and install command line tools. You'll need some dependencies to generate a PDF:
+    * pandoc: http://johnmacfarlane.net/pandoc/installing.html
+    * xelatex: http://tug.org/mactex/
 4. `$ makeebooks zh` #will produce a mobi
 
 # Errata


### PR DESCRIPTION
I tried generating a PDF with `makepdfs en`, but got an error like this:

```
Missing dependencies: pandoc, xelatex.
Install these and try again.
```

I'm using a more or less vanilla version of MacOSX 10.8, so chances are that most Mac users will be missing these dependencies. 

One other hiccup I've encountered is that you need the full MacTeX package, not the minimal one. Installing the minimal one resulted with an error that showed up in issue #367. Having the full one installed fixes the issue.
