### PR TITLE
added code to find ebook-convert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'maruku'
 gem 'redcarpet'
+gem 'rdiscount'

--- a/makeebooks
+++ b/makeebooks
@@ -99,7 +99,16 @@ ARGV.each do |lang|
       output.write(book_content)
     end
 
-    system('ebook-convert', "progit.#{lang}.html", "progit.#{lang}.#{format}",
+    $ebook_convert_cmd = ENV['ebook_convert_path'].to_s
+    if $ebook_convert_cmd.empty?
+      $ebook_convert_cmd = `which ebook-convert`.chomp
+    end
+    if $ebook_convert_cmd.empty?
+      mac_osx_path = '/Applications/calibre.app/Contents/MacOS/ebook-convert'
+      $ebook_convert_cmd = mac_osx_path
+    end
+
+    system($ebook_convert_cmd, "progit.#{lang}.html", "progit.#{lang}.#{format}",
            '--cover', 'ebooks/cover.png',
            '--authors', authors,
            '--comments', comments,


### PR DESCRIPTION
Ran into a few issues generating the mobi file.

I copied code from ebook:check to makeebook, so when the check passed, it properly generated the mobi file for me.

If you don't want the duplicate code, please advise a direction, and I can revise pull request to try again.

The only alternative I saw was to convert makeebook into a ruby script/class and leverage from the rake task ebook:check. But didn't want to suggest that route if you thought it introduced too much change.

(On a side, do you suggest using this workflow for other publishers, or would you advise a different path?)

Thanks again for this example.
Keenan
