### PR TITLE
[es] Chapter 09 Fixing typo for "entesijos"

### DIFF
--- a/es/09-git-internals/01-chapter9.markdown
+++ b/es/09-git-internals/01-chapter9.markdown
@@ -1,4 +1,4 @@
-# Los entesijos internos de Git #
+# Los entresijos internos de Git #
 
 Puedes que hayas llegado a este capítulo saltando desde alguno previo o puede que hayas llegado tras leer todo el resto del libro. --En uno u otro caso, aquí es donde aprenderás acerca del funcionamiento interno y la implementación de Git--. Me parece que esta información es realmente importante para entender cúan util y potente es Git. Pero algunas personas opinan que puede ser confuso e innecesariamente complejo para novatos. Por ello, lo he puesto al final del libro; de tal forma que puedas leerlo antes o después, en cualquier momento, a lo largo de tu proceso de aprendizaje. Lo dejo en tus manos.
 


### PR DESCRIPTION
According to the [RAE](http://lema.rae.es/drae/?val=entesijos) the correct
spelling is "entresijos" : cosa oculta.
