### PR TITLE
Fix typo in Chapter 5, section "Public Large Project", in `format-patch` example

### DIFF
--- a/en/05-distributed-git/01-chapter5.markdown
+++ b/en/05-distributed-git/01-chapter5.markdown
@@ -517,7 +517,7 @@ The `format-patch` command prints out the names of the patch files it creates. T
 	--
 	1.6.2.rc1.20.g8c5b.dirty
 
-You can also edit these patch files to add more information for the e-mail list that you don’t want to show up in the commit message. If you add text between the `--` line and the beginning of the patch (the `lib/simplegit.rb` line), then developers can read it; but applying the patch excludes it.
+You can also edit these patch files to add more information for the e-mail list that you don’t want to show up in the commit message. If you add text between the `---` line and the beginning of the patch (the `lib/simplegit.rb` line), then developers can read it; but applying the patch excludes it.
 
 To e-mail this to a mailing list, you can either paste the file into your e-mail program or send it via a command-line program. Pasting the text often causes formatting issues, especially with "smarter" clients that don’t preserve newlines and other whitespace appropriately. Luckily, Git provides a tool to help you send properly formatted patches via IMAP, which may be easier for you. I’ll demonstrate how to send a patch via Gmail, which happens to be the e-mail agent I use; you can read detailed instructions for a number of mail programs at the end of the aforementioned `Documentation/SubmittingPatches` file in the Git source code.
 


### PR DESCRIPTION
Fixes issue github/gitscm-next#313

Chapter 5 contains a typo (two hyphens instead of the correct three
hyphens) in an example for `format-patch` in the Public Large Project
section.
