### PR TITLE
Add bug info for pandoc to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ On MacOS you can do like this::
     * xelatex: http://tug.org/mactex/
 4. `$ makeebooks zh` #will produce a mobi
 
+## Notes on pandoc
+
+Please use Pandoc version 1.11.1 or later as older versions(confirmed on 1.9.1.1) has a [bug](https://github.com/jgm/pandoc/issues/964) which hides a word after tilde `~`.  You can do `pandoc -v` to see which version you have installed.
+
 # Errata
 
 If you see anything that is technically wrong or otherwise in need of


### PR DESCRIPTION
Pandoc version 1.9.1.1, which is installed with `apt-get` on Ubuntu 12.04, has a [bug](https://github.com/jgm/pandoc/issues/964) that hides a word after tilde.  It is fixed with Pandoc version 1.11.1.
