### PR TITLE
Adding note that Mac OS X users should use .profile

### DIFF
--- a/en/02-git-basics/01-chapter2.markdown
+++ b/en/02-git-basics/01-chapter2.markdown
@@ -1112,7 +1112,7 @@ Before we finish this chapter on basic Git, a few little tips and tricks may mak
 
 ### Auto-Completion ###
 
-If you use the Bash shell, Git comes with a nice auto-completion script you can enable. Download it directly from the Git source code at https://github.com/git/git/blob/master/contrib/completion/git-completion.bash . Copy this file to your home directory, and add this to your `.bashrc` file:
+If you use the Bash shell, Git comes with a nice auto-completion script you can enable. Download it directly from the Git source code at https://github.com/git/git/blob/master/contrib/completion/git-completion.bash . Copy this file to your home directory, and add this to your `~/.bashrc` file or `~/.profile` file (if you use Mac OS X):
 
 	source ~/git-completion.bash
 


### PR DESCRIPTION
Noting that Mac OS X users should use .profile file to do startup scripts because Mac OS X (or At least Mac OS X's Terminal App don't use .bashrc file because it create "login interactive" shell not the "not login" one that source .bashrc file)
