### PR TITLE
Explain: `git log --after=2008-10-01` has differing results, depending on time the command is run

### DIFF
--- a/en/02-git-basics/01-chapter2.markdown
+++ b/en/02-git-basics/01-chapter2.markdown
@@ -736,7 +736,7 @@ When using `git log` without specifying time,
 
     $ git log --after=2008-06-01 --before=2008-07-01
 
-the time defaults to the time at which the command is run on your computer (keeping the identical offset from UTC; effectively disregarding Daylight Saving Time). For example when the above command is executed at 09:00 on your computer with your timezone currently 3 hours ahead of UTC, then the result is equivalent to doing:
+the time defaults to the time at which the command is run on your computer (keeping the identical offset from UTC). For example when the above command is executed at 09:00 on your computer with your timezone currently 3 hours ahead of UTC, then the result is equivalent to doing:
 
     $ git log --after="2008-06-01T09:00:00+0300" \
       --before="2008-07-01T09:00:00+0300"


### PR DESCRIPTION
Command `git log --after="2008-10-01"` gives _completely different_ results, depending on the time at which you run the command!!

**Example**: If you execute the command at _09:00:00_ in the morning, then the result is identical to this:
`git log --after="2008-10-01 09:00:00"`

**Explanation**: If the time is not given, then it defaults to the time when the command is run. ;)
