### PR TITLE
Set dummy merge driver merge ours .gitattributes.

### DIFF
--- a/en/07-customizing-git/01-chapter7.markdown
+++ b/en/07-customizing-git/01-chapter7.markdown
@@ -535,6 +535,10 @@ This is helpful if a branch in your project has diverged or is specialized, but 
 
 	database.xml merge=ours
 
+And then define a dummy `ours` merge strategy with:
+
+    git config --global merge.ours.driver true
+
 If you merge in the other branch, instead of having merge conflicts with the database.xml file, you see something like this:
 
 	$ git merge topic


### PR DESCRIPTION
People don't know that they must set the `ours` driver in order for the `merge=ours` to work, or else Git silently ignores their inexistent driver.

The confusion is even greater considering that `ours` is a valid option to `merge -s recursive -X ours` 

I have seen this on two SO questions in which the OP explicitly mentions progit:

http://stackoverflow.com/questions/5465122/gitattributes-individual-merge-strategy-for-a-file
http://stackoverflow.com/questions/14093540/tell-git-to-use-ours-merge-strategy-on-specific-files

and it catches me every time I move machines.
