### PR TITLE
Add numeric color values to 07-customizing-git.

### DIFF
--- a/en/07-customizing-git/01-chapter7.markdown
+++ b/en/07-customizing-git/01-chapter7.markdown
@@ -130,7 +130,7 @@ In addition, each of these has subsettings you can use to set specific colors fo
 
 	$ git config --global color.diff.meta "blue black bold"
 
-You can set the color to any of the following values: normal, black, red, green, yellow, blue, magenta, cyan, or white. If you want an attribute like bold in the previous example, you can choose from bold, dim, ul, blink, and reverse.
+You can set the color to any of the following values: `normal`, `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, or `white`, or, if your terminal supports more than 16 colors, an arbitrary numeric color value (between 0 and 255 on a 256-color terminal). If you want an attribute like bold in the previous example, you can choose from `bold`, `dim`, `ul`, `blink`, and `reverse`.
 
 See the `git config` manpage for all the subsettings you can configure, if you want to do that.
 


### PR DESCRIPTION
In `en/07-customizing-git/01-chapter7.markdown`, add an explanation that users can specify numeric color values instead of string names when colorizing `git` output.
