### PR TITLE
[it] Update URL used in cURL to fetch from Grit library

### DIFF
--- a/it/09-git-internals/01-chapter9.markdown
+++ b/it/09-git-internals/01-chapter9.markdown
@@ -451,7 +451,7 @@ Torniamo agli oggetti del database per il tuo repository Git di test. A questo p
 
 Git comprime il contenuto di questi file con zlib e, poiché non stai memorizzando molte cose, complessivamente tutti questi file occupano solo 925 bytes. Aggiungeremo al repository del contenuto più pesante per dimostrare un’interessante caratteristica di Git. Aggiungi il file repo.rb dalla libreria Grit che abbiamo visto prima: sono circa 12K di sorgenti:
 
-	$ curl http://github.com/mojombo/grit/raw/master/lib/grit/repo.rb > repo.rb
+	$ curl -L http://github.com/mojombo/grit/raw/master/lib/grit/repo.rb > repo.rb
 	$ git add repo.rb 
 	$ git commit -m ‘aggiunto repo.rb'
 	[master 484a592] aggiunto repo.rb


### PR DESCRIPTION
Add -L flag to cURL command to follow any redirects

cURL by default will not follow redirects, leading
to blank file unless the `-L` flag is included since
all resources once hosted on raw.github.com are now
on the raw.githubusercontent.com domain.

Fixes issue mentioned at https://github.com/git/git-scm.com/issues/422
See also PR #811
