### PR TITLE
[it] Updating macports git package name

### DIFF
--- a/it/01-introduction/01-chapter1.markdown
+++ b/it/01-introduction/01-chapter1.markdown
@@ -170,7 +170,7 @@ Figura 1-7. Installer di Git per OS X.
 
 L'altro metodo è installare Git con MacPorts (`http://www.macports.org`). Se hai MacPorts installato puoi farlo con:
 
-	$ sudo port install git-core +svn +doc +bash_completion +gitweb
+	$ sudo port install git +svn +doc +bash_completion +gitweb
 
 Non ti occorre aggiungere tutti i pacchetti extra, ma probabilmente vorrai includere +svn, nel caso tu debba usare Git con i repository di Subversion (vedi Capitolo 8).
 


### PR DESCRIPTION
git-core has been made obsolete by the port git
