### PR TITLE
Fix chapter 9: decimal, not hex

### DIFF
--- a/en/09-git-internals/01-chapter9.markdown
+++ b/en/09-git-internals/01-chapter9.markdown
@@ -718,7 +718,7 @@ For example, say you run `git push origin master` in your project, and `origin` 
 
 The `git-receive-pack` command immediately responds with one line for each reference it currently has — in this case, just the `master` branch and its SHA. The first line also has a list of the server’s capabilities (here, `report-status` and `delete-refs`).
 
-Each line starts with a 4-byte hex value specifying how long the rest of the line is. Your first line starts with 005b, which is 91 in hex, meaning that 91 bytes remain on that line. The next line starts with 003e, which is 62, so you read the remaining 62 bytes. The next line is 0000, meaning the server is done with its references listing.
+Each line starts with a 4-byte hex value specifying how long the rest of the line is. Your first line starts with 005b, which is 91 in decimal, meaning that 91 bytes remain on that line. The next line starts with 003e, which is 62, so you read the remaining 62 bytes. The next line is 0000, meaning the server is done with its references listing.
 
 Now that it knows the server’s state, your `send-pack` process determines what commits it has that the server doesn’t. For each reference that this push will update, the `send-pack` process tells the `receive-pack` process that information. For instance, if you’re updating the `master` branch and adding an `experiment` branch, the `send-pack` response may look something like this:
 


### PR DESCRIPTION
I am not a native English speaker, but about hexadecimal, it's often used as in http://en.wikipedia.org/wiki/Hexadecimal
> Thus `&#x2019`; represents the curled right single quote (Unicode value 2019 in hex, 8217 in decimal).

so I think the original `which is 91 in hex` is a bit ambiguous, should be `which is 91 in decimal`