### PR TITLE
Fix git stash-unapply example

### DIFF
--- a/az/06-git-tools/01-chapter6.markdown
+++ b/az/06-git-tools/01-chapter6.markdown
@@ -501,7 +501,7 @@ Again, if you don’t specify a stash, Git assumes the most recent stash:
 You may want to create an alias and effectively add a `stash-unapply` command to your git. For example:
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 

--- a/cs/06-git-tools/01-chapter6.markdown
+++ b/cs/06-git-tools/01-chapter6.markdown
@@ -518,7 +518,7 @@ Jestliže nespecifikujete konkrétní odklad, Git předpokládá odklad posledn�
 Můžete si také vytvořit alias a do svého gitu přidat například příkaz `stash-unapply`:
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 

--- a/de/06-git-tools/01-chapter6.markdown
+++ b/de/06-git-tools/01-chapter6.markdown
@@ -660,7 +660,7 @@ An dieser Stelle noch einmal der Hinweis, dass Git den zuletzt erstellten Stash 
 Wenn Du dieses Feature öfters benötigst, ist es wahrscheinlich sinnvoll, einen Alias `stash-unapply` in Git dafür anzulegen:
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 

--- a/en/06-git-tools/01-chapter6.markdown
+++ b/en/06-git-tools/01-chapter6.markdown
@@ -501,7 +501,7 @@ Again, if you don’t specify a stash, Git assumes the most recent stash:
 You may want to create an alias and effectively add a `stash-unapply` command to your Git. For example:
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 

--- a/fr/06-git-tools/01-chapter6.markdown
+++ b/fr/06-git-tools/01-chapter6.markdown
@@ -577,7 +577,7 @@ La création d'un alias permettra d'ajouter effectivement la commande `stash-una
 Par exemple :
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 

--- a/it/06-git-tools/01-chapter6.markdown
+++ b/it/06-git-tools/01-chapter6.markdown
@@ -501,7 +501,7 @@ Di nuovo, se non specifichi un accantonamento, Git assume che sia l'ultimo:
 Puoi voler creare un alias per avere un comando `stash-unapply` nel tuo Git. Per esempio:
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 

--- a/ja/06-git-tools/01-chapter6.markdown
+++ b/ja/06-git-tools/01-chapter6.markdown
@@ -496,7 +496,7 @@ apply オプションは、スタックに隠した作業を再度適用する�
 次の例のようにエイリアスを作れば、Git に `stash-unapply` コマンドを追加したのと事実上同じことになります。
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... 何か作業をして ...
     $ git stash-unapply
 

--- a/ko/06-git-tools/01-chapter6.markdown
+++ b/ko/06-git-tools/01-chapter6.markdown
@@ -497,7 +497,7 @@ Stash를 명시하지 않으면 Git은 가장 최근의 Stash를 사용한다:
 `stash-unapply`라는 alias를 만들고 편리하게 할 수도 있다:
 
 	$ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-	$ git stash
+	$ git stash apply
 	$ #... work work work
 	$ git stash-unapply
 

--- a/nl/06-git-tools/01-chapter6.markdown
+++ b/nl/06-git-tools/01-chapter6.markdown
@@ -538,7 +538,7 @@ Nogmaals: als je geen stash specificeert gaat Git van de meest recente stash uit
 Wellicht wil je een alias maken en effectief een `stash-unapply` commando aan je Git toevoegen. Bijvoorbeeld:
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 

--- a/no-nb/06-git-tools/01-chapter6.markdown
+++ b/no-nb/06-git-tools/01-chapter6.markdown
@@ -501,7 +501,7 @@ Again, if you don’t specify a stash, Git assumes the most recent stash:
 You may want to create an alias and effectively add a `stash-unapply` command to your Git. For example:
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 

--- a/pl/06-git-tools/01-chapter6.markdown
+++ b/pl/06-git-tools/01-chapter6.markdown
@@ -683,7 +683,7 @@ Możesz chcieć stworzyć alias i dodać komendę `stash-unapply` do Gita. Na pr
 <!-- You may want to create an alias and effectively add a `stash-unapply` command to your git. For example: -->
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 

--- a/pt-br/06-git-tools/01-chapter6.markdown
+++ b/pt-br/06-git-tools/01-chapter6.markdown
@@ -497,7 +497,7 @@ Novamente, se você não especificar um stash, Git assume que é o stash mais re
 Você pode querer criar um alias e adicionar explicitamente um comando `stash-unapply` no seu git. Por exemplo:
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 

--- a/ru/06-git-tools/01-chapter6.markdown
+++ b/ru/06-git-tools/01-chapter6.markdown
@@ -501,7 +501,7 @@ Insert 18333fig0601.png
 Если хотите, сделайте псевдоним и добавьте в свой Git команду `stash-unapply`. Например, так:
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 

--- a/zh-tw/06-git-tools/01-chapter6.markdown
+++ b/zh-tw/06-git-tools/01-chapter6.markdown
@@ -500,7 +500,7 @@ apply 選項只嘗試應用儲藏的工作——儲藏的內容仍然在堆疊�
 你可能會想要新建一個別名，在你的 git 增加一個 `stash-unapply` 命令，這樣更有效率。例如：
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 

--- a/zh/06-git-tools/01-chapter6.markdown
+++ b/zh/06-git-tools/01-chapter6.markdown
@@ -500,7 +500,7 @@ apply 选项只尝试应用储藏的工作——储藏的内容仍然在栈上�
 你可能会想要新建一个別名，在你的 Git 里增加一个 `stash-unapply` 命令，这样更有效率。例如：
 
     $ git config --global alias.stash-unapply '!git stash show -p | git apply -R'
-    $ git stash
+    $ git stash apply
     $ #... work work work
     $ git stash-unapply
 


### PR DESCRIPTION
The example for `git stash-unapply` starts with `git stash` which will
create a new stash and not apply a stash to the working copy.  The first
command should be either `git stash apply` (which is what I changed it
to) or `git stash apply stash@{0}` or a variant thereof.

Closes Issue #915 
