### PR TITLE
Update gitweb apache example for apache2.4

### DIFF
--- a/en/04-git-server/01-chapter4.markdown
+++ b/en/04-git-server/01-chapter4.markdown
@@ -355,7 +355,7 @@ Notice that you have to tell the command where to find your Git repositories wit
 	    ServerName gitserver
 	    DocumentRoot /var/www/gitweb
 	    <Directory /var/www/gitweb>
-	        Options ExecCGI +FollowSymLinks +SymLinksIfOwnerMatch
+	        Options +ExecCGI +FollowSymLinks +SymLinksIfOwnerMatch
 	        AllowOverride All
 	        order allow,deny
 	        Allow from all


### PR DESCRIPTION
In apache2.4 mixing `Options` with a `+` or a `-` with those without
will cause startup to abort. This patch updates the example gitweb
apache virtualserver to a valid configuration for apache2.4.